### PR TITLE
agent: upgrade to caracal v0.15.2 to fix mangled lines on stdout

### DIFF
--- a/dockerfiles/iris-agent.dockerfile
+++ b/dockerfiles/iris-agent.dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
         zstd \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/dioptra-io/caracal/releases/download/v0.15.1/caracal-linux-amd64 > /usr/bin/caracal \
+RUN curl -L https://github.com/dioptra-io/caracal/releases/download/v0.15.2/caracal-linux-amd64 > /usr/bin/caracal \
     && chmod +x /usr/bin/caracal
 
 WORKDIR /app

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -21,7 +21,7 @@ To be able to access them from your own machine, you need to add the following e
 You also need caracal in your $PATH if you intend to run Iris locally:
 ```bash
 # Use caracal-macos-amd64 for macOS
-curl -L https://github.com/dioptra-io/caracal/releases/download/v0.15.1/caracal-linux-amd64 > /usr/bin/caracal
+curl -L https://github.com/dioptra-io/caracal/releases/download/v0.15.2/caracal-linux-amd64 > /usr/bin/caracal
 chmod +x /usr/bin/caracal
 ```
 


### PR DESCRIPTION
See https://github.com/dioptra-io/caracal/pull/61.

@SaiedKazemi the next steps would be:
1. Merge this PR
2. Merge main into production and wait for the new images to be built
3. Wait for watchtower to upgrade the containers, or `iris down && iris pull && iris up -d`
4. Upgrade GCP infrastructure: `terraform destroy && terraform apply`
5. Cancel the running measurements and trigger a new scheduler run