### PR TITLE
Reduce verbosity of logs for diamond-miner and httpx packages

### DIFF
--- a/iris/commons/logger.py
+++ b/iris/commons/logger.py
@@ -2,6 +2,8 @@ import logging
 
 base_logger = logging.getLogger("iris")
 
+logging.getLogger("diamond-miner").setLevel(logging.WARNING)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 class Adapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):


### PR DESCRIPTION
Set logging level to WARNING for diamond-miner and httpx to filter out noisy logs. 
Tested changes on a GCP VM to confirm less verbose output.